### PR TITLE
feat: add `start_section_number` `start_subsection_number` and `remove_trailing_dot` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ This plugin comes with the following defaults:
 {
     max_level = 4, -- stop to add section number after max_level
     min_level = 1, -- start to add section number after min_level
+    start_section_number = 1, -- section number start from this number (default: 1)
+    start_subsection_number = 1, -- sub-level section numbers start from this number (default: 1)
+    remove_trailing_dot = false, -- remove trailing dot from section numbers (default: false)
     ignore_pairs = { -- the markdown content in these pairs will be ignored
         { "```", "```" },
         { "\\~\\~\\~", "\\~\\~\\~" },
@@ -50,8 +53,64 @@ This plugin comes with the following defaults:
         position = "right",
         indent_space_number = 2,
         header_prefix = "- ",
+        toc_level = 6,
     },
 }
+```
+
+### Key Options
+
+- `max_level` and `min_level`: Control which header levels get numbered
+- `start_section_number` and `start_subsection_number`: Set starting numbers
+- `remove_trailing_dot`: Remove trailing dots from section numbers
+- `ignore_pairs`: Content blocks to exclude from numbering
+
+### Configuration Examples
+
+#### Basic Setup
+
+```lua
+require("md_section_number").setup({
+    min_level = 1,
+    max_level = 3,
+    remove_trailing_dot = true,
+})
+```
+
+#### Custom Starting Numbers
+
+```lua
+require("md_section_number").setup({
+    start_section_number = 0,
+    start_subsection_number = 1,
+})
+```
+
+#### With TOC Customization
+
+```lua
+require("md_section_number").setup({
+    max_level = 3,
+    toc = {
+        width = 40,
+        position = "left",
+        header_prefix = "• ",
+        toc_level = 3,
+    },
+})
+```
+
+#### Custom Ignore Patterns
+
+```lua
+require("md_section_number").setup({
+    ignore_pairs = {
+        { "```", "```" },
+        { "\\~\\~\\~", "\\~\\~\\~" },
+        { "<!--", "-->" },
+        { "{{", "}}" },
+    },
+})
 ```
 
 ### Commands

--- a/lua/md_section_number.lua
+++ b/lua/md_section_number.lua
@@ -6,6 +6,9 @@ local M = {}
 local DEFAULT_OPTS = {
   max_level = 4,
   min_level = 1,
+  start_section_number = 1,
+  start_subsection_number = 1,
+  remove_trailing_dot = false,
   ignore_pairs = {
     { "```", "```" },
     { "\\~\\~\\~", "\\~\\~\\~" },

--- a/lua/md_section_number/heading/replacer.lua
+++ b/lua/md_section_number/heading/replacer.lua
@@ -1,23 +1,11 @@
 local M = {}
 
 M.heading_number_base_pattern = "%d+%."
-M.max_level = 4
-M.min_level = 1
-
-local function get_heading_number_index(str)
-  local pattern = M.heading_number_base_pattern
-  local max_s, max_e
-  repeat
-    local s, e = string.find(str, pattern)
-    pattern = pattern .. M.heading_number_base_pattern
-    if s ~= nil then
-      max_s = s
-      max_e = e
-    end
-  until s == nil
-
-  return max_s, max_e
-end
+M.max_level = nil
+M.min_level = nil
+M.start_section_number = nil
+M.start_subsection_number = nil
+M.remove_trailing_dot = nil
 
 function M.update_line(start_line, line_length, line_content)
   vim.api.nvim_buf_set_text(0, start_line, 0, start_line, line_length, { line_content })
@@ -31,54 +19,94 @@ function M.replaceHeadingNumber(source_heading, heading_number, level, is_clear)
   if level > max_level or level < M.min_level then
     heading_number = ""
   end
-  if string.len(heading_number) > 0 then
-    heading_number = " " .. heading_number
+  -- Extract the hash part first
+  local hash_part = string.rep("#", level)
+  -- Extract title content, removing hashes and possible existing numbering
+  local content_part = string.match(source_heading, "^#+%s*(.*)")
+  if not content_part then
+    content_part = ""
   end
-  local s, e = get_heading_number_index(source_heading)
-  if nil == s or s ~= level + 2 then
-    return string.rep("#", level) .. heading_number .. " " .. vim.trim(string.sub(source_heading, level + 1, -1))
+  -- Remove leading numbering pattern (like "1.2.3. ")
+  content_part = string.gsub(content_part, "^[%d%.]+%s+", "")
+  content_part = vim.trim(content_part)
+  -- Handle numbering format
+  local number_part = ""
+  if not is_clear and string.len(heading_number) > 0 then
+    number_part = " " .. heading_number
   end
-  return string.rep("#", level) .. heading_number .. " " .. vim.trim(string.sub(source_heading, e + 1, -1))
+  -- Rebuild the heading
+  return hash_part .. number_part .. " " .. content_part
 end
 
--- @table heading_lines {{heading_line_index,heading_line_content,heading_level},{}}
 function M.insert_heading_number(heading_lines)
   local level_depth = {}
 
   for i = 1, #heading_lines do
     local level = heading_lines[i][3]
+    
     if i == 1 then
-      level_depth[level] = 1
-      goto continue
-    end
-
-    if not level_depth[level] then
-      level_depth[level] = 0
-    end
-    if heading_lines[i][3] < heading_lines[i - 1][3] then
-      level_depth[level] = level_depth[level] + 1
-    end
-    if heading_lines[i][3] == heading_lines[i - 1][3] then
-      level_depth[level] = level_depth[level] + 1
-    end
-    if heading_lines[i][3] > heading_lines[i - 1][3] then
-      for inner_level = heading_lines[i - 1][3] + 1, heading_lines[i][3] - 1 do
-        level_depth[inner_level] = 0
+      -- First heading: initialize with start_section_number
+      level_depth[level] = M.start_section_number
+    else
+      local prev_level = heading_lines[i - 1][3]
+      
+      if level == prev_level then
+        -- Same level: increment counter
+        level_depth[level] = level_depth[level] + 1
+      elseif level < prev_level then
+        -- Going to higher level (less #): increment existing counter and reset deeper levels
+        if level_depth[level] then
+          level_depth[level] = level_depth[level] + 1
+        else
+          -- If this level hasn't been seen before, start from appropriate value
+          if level == M.min_level then
+            level_depth[level] = M.start_section_number
+          else
+            level_depth[level] = M.start_subsection_number
+          end
+        end
+        -- Reset all deeper levels to nil (will be initialized when needed)
+        for reset_level = level + 1, prev_level do
+          level_depth[reset_level] = nil
+        end
+      else
+        -- Going to deeper level (more #): handle level jumps
+        -- Initialize all skipped intermediate levels
+        for skip_level = prev_level + 1, level - 1 do
+          level_depth[skip_level] = M.start_subsection_number
+        end
+        -- Set current level to start_subsection_number
+        level_depth[level] = M.start_subsection_number
       end
-      level_depth[level] = 1
     end
 
-    ::continue::
+    -- Generate heading number
     local heading_number = ""
     for j = M.min_level, level do
-      heading_number = heading_number .. (level_depth[j] or 0) .. "."
+      local number
+      if level_depth[j] then
+        number = level_depth[j]
+      else
+        -- Initialize missing levels
+        if j == M.min_level then
+          number = M.start_section_number
+          level_depth[j] = number
+        else
+          number = M.start_subsection_number
+          level_depth[j] = number
+        end
+      end
+      heading_number = heading_number .. number .. "."
+    end
+    
+    if M.remove_trailing_dot and string.sub(heading_number, -1) == "." then
+      heading_number = string.sub(heading_number, 1, -2)
     end
     table.insert(heading_lines[i], heading_number)
   end
   return heading_lines
 end
 
--- @table heading_lines {heading_line_index,heading_line_content,heading_level}
 function M.change_heading_level(heading_line, offset)
   local target_level
   if offset < 0 and math.abs(offset) >= heading_line[3] then
@@ -86,15 +114,19 @@ function M.change_heading_level(heading_line, offset)
   else
     target_level = heading_line[3] + offset
   end
-  local _, e = get_heading_number_index(heading_line[1])
-  local heading_content
-  if e == nil then
-    heading_content = string.rep("#", target_level)
-      .. " "
-      .. vim.trim(string.sub(heading_line[2], heading_line[3] + 1, -1))
-  else
-    heading_content = string.rep("#", target_level) .. vim.trim(string.sub(heading_line[2], e + 1, -1))
+
+  -- Extract title content, removing hashes and possible existing numbering (using same logic as replaceHeadingNumber)
+  local content_part = string.match(heading_line[2], "^#+%s*(.*)")
+  if not content_part then
+    content_part = ""
   end
+
+  -- Remove leading numbering pattern (like "1.2.3. ")
+  content_part = string.gsub(content_part, "^[%d%.]+%s+", "")
+  content_part = vim.trim(content_part)
+
+  local heading_content = string.rep("#", target_level) .. " " .. content_part
+
   return {
     heading_line[1],
     heading_content,
@@ -103,13 +135,25 @@ function M.change_heading_level(heading_line, offset)
 end
 
 function M.setup(opts)
-  M.max_level = opts.max_level or M.max_level
+  -- Set all configuration values from opts
+  M.max_level = opts.max_level
+  M.min_level = opts.min_level
+  M.start_section_number = opts.start_section_number
+  M.start_subsection_number = opts.start_subsection_number
+  M.remove_trailing_dot = opts.remove_trailing_dot
+  
+  -- Validate and apply constraints
   if M.max_level < 0 then
     M.max_level = 4
   end
-  M.min_level = opts.min_level or M.min_level
   if M.min_level < 1 then
     M.min_level = 1
+  end
+  if M.start_section_number < 0 then
+    M.start_section_number = 0
+  end
+  if M.start_subsection_number < 0 then
+    M.start_subsection_number = 0
   end
 end
 


### PR DESCRIPTION
feat: add `start_section_number` `start_subsection_number` and `remove_trailing_dot` options

Add new configuration options:
    - `start_section_number` and `start_subsection_number`: Allows setting the starting number for section numbering.
    - `remove_trailing_dot`: Enables removing trailing dots from section numbers.

Updated documentation with examples and adjusted logic in the heading replacer to support these options.